### PR TITLE
fix(scripts): order hf download args correctly for new hf CLI

### DIFF
--- a/scripts/download_ternary.sh
+++ b/scripts/download_ternary.sh
@@ -61,10 +61,12 @@ fi
 # ── Download from HuggingFace ────────────────────────────────────────────────
 echo "Downloading $REPO  (using: $HF_CMD)..."
 hf_download() {
+    # The new `hf` CLI's argparse requires positional `filenames` to appear
+    # before optional flags; older `huggingface-cli` was order-agnostic.
     "$HF_CMD" download "$REPO" \
+        "$@" \
         --local-dir "$LOCAL_DIR" \
-        "${HF_PARALLEL_ARGS[@]}" \
-        "$@"
+        "${HF_PARALLEL_ARGS[@]}"
 }
 
 # Download metadata files first (always present).


### PR DESCRIPTION
## Summary

`scripts/download_ternary.sh` calls `hf download` with positional filenames *after* `--local-dir` and `--max-workers`. On my machine with `huggingface_hub` 0.36.1 (the current release), this fails with:

```
hf: error: unrecognized arguments: model.safetensors
```

`hf download --help` reports its signature as `repo_id [filenames ...]` followed by options, suggesting positional args should appear before flags. Moving them there makes the script complete end-to-end. Behavior should be unchanged on the older `huggingface-cli` (which appears to have been more lenient about ordering).

## Caveat -- this might be something I missed

I am new to this codebase and may not have the full context for how this script is meant to be run. A few things I am not sure about:

- Whether maintainers run this with an older `huggingface-cli` (in which case the old ordering worked fine and the new `hf` parser is the actual change in environment, not a bug in this script).
- Whether there is a known-good `huggingface_hub` version pinned somewhere that I should have used instead.
- Whether I am invoking the script in a way that was never intended.

If any of those apply, please feel free to close this PR. It's a small enough change that I won't be hurt if it turns out to be a user-side issue.

## Repro

On a machine where only `hf` is installed (default for current `pip install huggingface_hub`):

```
./scripts/download_ternary.sh 1.7b
```

Before this change: fails with the argparse error and exits non-zero before `oxibonsai convert` runs.
After: completes through download, convert, and produces `models/Ternary-Bonsai-1.7B.gguf` plus the tokenizer.

## Test plan

- [x] `./scripts/download_ternary.sh 1.7b` -- downloads, converts, produces `models/Ternary-Bonsai-1.7B.gguf` (515 MB) plus `models/tokenizer.json` (11 MB).
- [x] `./scripts/download_ternary.sh 4b` -- same flow, produces `models/Ternary-Bonsai-4B.gguf` (1.1 GB) plus tokenizer.
- [x] Tested with `huggingface_hub` 0.36.1 on macOS Apple Silicon (arm64).
- [ ] Not retested with older `huggingface-cli` -- the older parser appears to be order-agnostic, so the change should be a no-op there. Happy to verify if a maintainer has an older environment handy.