### PR TITLE
fix(model): read head_dim from GGUF metadata for Qwen3-4B

### DIFF
--- a/crates/oxibonsai-core/src/config.rs
+++ b/crates/oxibonsai-core/src/config.rs
@@ -97,7 +97,16 @@ impl Qwen3Config {
             .or_else(|_| metadata.get_f32(keys::LLM_ROPE_FREQ_BASE))
             .unwrap_or(1_000_000.0);
 
-        let head_dim = hidden_size / num_attention_heads;
+        // head_dim is read explicitly from metadata when present, since for some
+        // Qwen3 sizes (notably Qwen3-4B: hidden=2560, heads=32, head_dim=128)
+        // the value is not hidden_size / num_attention_heads. Older GGUFs that
+        // omit the key fall back to the derivation, which still holds for the
+        // 8B and 1.7B variants in this project.
+        let head_dim = metadata
+            .get_u32(&format!("{arch_prefix}.attention.key_length"))
+            .or_else(|_| metadata.get_u32(keys::LLM_ATTENTION_KEY_LENGTH))
+            .map(|v| v as usize)
+            .unwrap_or(hidden_size / num_attention_heads);
 
         Ok(Qwen3Config {
             hidden_size,

--- a/crates/oxibonsai-core/src/gguf/tensor_info.rs
+++ b/crates/oxibonsai-core/src/gguf/tensor_info.rs
@@ -196,6 +196,7 @@ pub mod keys {
     pub const LLM_FEED_FORWARD_LENGTH: &str = "llm.feed_forward_length";
     pub const LLM_ATTENTION_HEAD_COUNT: &str = "llm.attention.head_count";
     pub const LLM_ATTENTION_HEAD_COUNT_KV: &str = "llm.attention.head_count_kv";
+    pub const LLM_ATTENTION_KEY_LENGTH: &str = "llm.attention.key_length";
     pub const LLM_ATTENTION_LAYER_NORM_RMS_EPSILON: &str = "llm.attention.layer_norm_rms_epsilon";
     pub const LLM_ROPE_FREQ_BASE: &str = "llm.rope.freq_base";
     pub const LLM_VOCAB_SIZE: &str = "llm.vocab_size";

--- a/crates/oxibonsai-model/src/convert/common.rs
+++ b/crates/oxibonsai-model/src/convert/common.rs
@@ -77,7 +77,7 @@ pub fn write_metadata(
         MetadataWriteValue::Str("TQ2_0_G128".to_string()),
     );
 
-    // Integer keys (u32)
+    // Integer keys (u32) - required.
     let u32_keys = [
         (keys::LLM_BLOCK_COUNT, "num_hidden_layers"),
         (keys::LLM_EMBEDDING_LENGTH, "hidden_size"),
@@ -93,6 +93,18 @@ pub fn write_metadata(
         } else {
             tracing::warn!(json_key, "missing or non-u64 field in config.json");
         }
+    }
+
+    // head_dim is optional in config.json: Qwen3 (1.7B/4B/8B/14B) sets it
+    // explicitly because head_dim is decoupled from hidden_size/num_heads
+    // (notably Qwen3-4B has hidden=2560, heads=32, head_dim=128, so the
+    // derived hidden/heads=80 is wrong). Older Qwen2 configs omit it and
+    // the reader falls back to the hidden/heads derivation.
+    if let Some(val) = config.get("head_dim").and_then(Value::as_u64) {
+        writer.add_metadata(
+            keys::LLM_ATTENTION_KEY_LENGTH,
+            MetadataWriteValue::U32(val as u32),
+        );
     }
 
     // rms_norm_eps → F32


### PR DESCRIPTION
## Summary

Following the documented Quick Start path (`./scripts/download_ternary.sh 4b`), I produced a `Ternary-Bonsai-4B.gguf` that fails to load at runtime with:

```
Error: model error: shape mismatch for 'LinearTernary': expected [51200], got [81920]
```

I traced this to `crates/oxibonsai-core/src/config.rs:100`, which derives `head_dim = hidden_size / num_attention_heads`. For Qwen3-4B this gives `2560 / 32 = 80`, but the upstream `Qwen/Qwen3-4B/config.json` sets `head_dim = 128` explicitly. The convert path correctly produces tensors with shape `[hidden, num_q_heads * head_dim] = [2560, 4096]`, but the loader's derived `head_dim = 80` makes it expect `[2560, 32 * 80] = [2560, 2560]`. The LinearTernary block-count check then mismatches by exactly the factor 128/80 = 1.6, which lines up with the observed `81920 / 51200 = 1.6`.

## Proposed fix

Three small changes (24 insertions, 2 deletions):

- `crates/oxibonsai-core/src/gguf/tensor_info.rs`: add `LLM_ATTENTION_KEY_LENGTH` constant matching llama.cpp's key naming.
- `crates/oxibonsai-model/src/convert/common.rs`: write `head_dim` from `config.json` into the new key during conversion when present (Qwen3 1.7B / 4B / 8B / 14B all set it explicitly).
- `crates/oxibonsai-core/src/config.rs`: prefer reading the key, fall back to `hidden_size / num_attention_heads` when absent. This preserves behavior for existing GGUFs that do not carry the key.

## Possible caveats -- I might be missing context

I am new to this codebase and may not understand the architectural decisions. Specifically:

- Is there a known constraint where `head_dim` is intentionally derived from `hidden_size / num_attention_heads`? Maybe model variants in this project are expected to satisfy that relationship and Qwen3-4B was never an intended target?
- The `Qwen3Config::bonsai_4b()` constructor in `config.rs` defines a different architecture from upstream Qwen3-4B: `hidden=2560, num_heads=20, head_dim=128`. The documented `./scripts/download_ternary.sh 4b` flow points at `prism-ml/Ternary-Bonsai-4B-unpacked`, whose `config.json` matches upstream Qwen3-4B (`num_heads=32, head_dim=128`). It is possible the intent is for the project's own 4B variant to use the `bonsai_4b()` shape and that the prism-ml unpacked repo isn't the right source. If so, please point me at the right one.
- I noticed that `oxibonsai info` reports `head_dim: 80` on the 4B file produced by the project's own convert pipeline, which suggested to me this was a bug -- but it is entirely possible I am misreading the situation.

If any of those apply, please feel free to close this PR. I would also welcome a pointer to the right way to load the 4B variant if I am holding it wrong.

## Verification

- Before this change: `oxibonsai run --model models/Ternary-Bonsai-4B.gguf ...` fails with the LinearTernary shape error above.
- After re-converting `Ternary-Bonsai-4B.gguf` with the updated convert path: `oxibonsai info --json` reports `"head_dim": 128` (was 80) and `"metadata_entries": 13` (was 12). Inference then runs end-to-end on both NEON CPU and Metal on macOS Apple Silicon.
- The existing 1.7B and 8B GGUFs (which had no `head_dim` metadata key before this change) continue to load via the fallback path with no behavior change.

## Notes

- The fix is additive in both directions: the writer emits a new key; the reader is backwards-compatible with GGUFs that lack it. No re-conversion is required for 1.7B/8B users.
- I have not touched the `Qwen3Config::bonsai_4b()` reference constructor, since I do not know its intent. If it should be aligned with upstream Qwen3-4B (`num_heads=32`) that is a separate decision.
- This PR is independent of #5 (a separate `hf` CLI argument-order fix). Either can land first.