### PR TITLE
fix(cuda): disable broken ternary batch prefill (KV-cache handoff bug)

### DIFF
--- a/crates/oxibonsai-kernels/tests/cuda_tq2_gemv_parity.rs
+++ b/crates/oxibonsai-kernels/tests/cuda_tq2_gemv_parity.rs
@@ -1,0 +1,119 @@
+//! Isolated CUDA TQ2 GEMV parity probe (debugging Blackwell garbage output).
+//!
+//! Compares the CUDA `gemv_tq2_g128_v1` kernel (via the self-contained
+//! `CudaGraph::encode_lm_head_gemv_tq2` upload→kernel→download path) against the
+//! CPU scalar reference `gemv_tq2_0_g128`, on the same deterministic ternary
+//! weights. If they diverge, the bug is in the TQ2 GEMV kernel or the AoS→SoA
+//! reformat — not in the fused full-forward orchestration.
+//!
+//! Run:
+//!   cargo test -p oxibonsai-kernels --features native-cuda \
+//!     --test cuda_tq2_gemv_parity -- --nocapture
+
+#[cfg(all(
+    feature = "native-cuda",
+    any(target_os = "linux", target_os = "windows")
+))]
+mod cuda_tq2 {
+    use half::f16;
+    use oxibonsai_core::BlockTQ2_0_g128;
+    use oxibonsai_kernels::gemv_ternary::gemv_tq2_0_g128;
+    use oxibonsai_kernels::CudaGraph;
+
+    /// Deterministic ternary blocks: vary qs codes (covering 0,1,2,3) and the
+    /// FP16 scale across blocks so the matrix is "interesting".
+    fn make_blocks(n_rows: usize, blocks_per_row: usize) -> Vec<BlockTQ2_0_g128> {
+        let mut blocks = Vec::with_capacity(n_rows * blocks_per_row);
+        for row in 0..n_rows {
+            for bk in 0..blocks_per_row {
+                let mut qs = [0u8; 32];
+                for (byte_idx, b) in qs.iter_mut().enumerate() {
+                    let seed = row * 31 + bk * 17 + byte_idx;
+                    let c0 = (seed % 3) as u8;
+                    let c1 = ((seed / 3) % 3) as u8;
+                    let c2 = ((seed / 9) % 3) as u8;
+                    let c3 = ((seed / 27) % 3) as u8;
+                    *b = c0 | (c1 << 2) | (c2 << 4) | (c3 << 6);
+                }
+                let scale = 0.25_f32 + 0.5_f32 * ((row * 7 + bk * 3) % 101) as f32 / 101.0;
+                blocks.push(BlockTQ2_0_g128 {
+                    qs,
+                    d: f16::from_f32(scale),
+                });
+            }
+        }
+        blocks
+    }
+
+    fn aos_bytes(blocks: &[BlockTQ2_0_g128]) -> &[u8] {
+        let ptr = blocks.as_ptr() as *const u8;
+        let len = std::mem::size_of_val(blocks);
+        unsafe { std::slice::from_raw_parts(ptr, len) }
+    }
+
+    fn run_case(n_rows: usize, k: usize, handle_id: u64) {
+        let blocks_per_row = k / 128;
+        let blocks = make_blocks(n_rows, blocks_per_row);
+        let input: Vec<f32> = (0..k).map(|i| (i as f32) * 0.001 - 0.3).collect();
+
+        // CPU reference.
+        let mut cpu = vec![0f32; n_rows];
+        gemv_tq2_0_g128(&blocks, &input, &mut cpu, n_rows, k).expect("cpu gemv");
+
+        // CUDA path.
+        let graph = match CudaGraph::global() {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!("no CUDA device ({e}) — skipping case n_rows={n_rows} k={k}");
+                return;
+            }
+        };
+        let cuda = graph
+            .encode_lm_head_gemv_tq2(&input, handle_id, aos_bytes(&blocks), n_rows, k)
+            .expect("cuda gemv");
+
+        // Compare.
+        let mut max_abs = 0f32;
+        let mut max_idx = 0usize;
+        for (i, (a, b)) in cpu.iter().zip(cuda.iter()).enumerate() {
+            let d = (a - b).abs();
+            if d > max_abs {
+                max_abs = d;
+                max_idx = i;
+            }
+        }
+        eprintln!(
+            "── n_rows={n_rows} k={k} (blocks_per_row={blocks_per_row}) ──\n\
+             max|Δ| = {max_abs:.6e} at row {max_idx}\n\
+             cpu[0..6]  = {:?}\n\
+             cuda[0..6] = {:?}\n\
+             cpu[{max_idx}]={} cuda[{max_idx}]={}",
+            &cpu[..6.min(n_rows)],
+            &cuda[..6.min(n_rows)],
+            cpu[max_idx],
+            cuda[max_idx],
+        );
+        assert!(
+            max_abs < 1e-2,
+            "CUDA TQ2 GEMV diverges from CPU reference: max|Δ|={max_abs:.6e} at row {max_idx} (n_rows={n_rows}, k={k})"
+        );
+    }
+
+    /// Real-8B inner dimension (hidden=4096 → 32 blocks/row).
+    #[test]
+    fn cuda_tq2_gemv_parity_k4096() {
+        run_case(512, 4096, 0xDEAD_0001);
+    }
+
+    /// Small shape (k=256 → 2 blocks/row), like the Metal unit test.
+    #[test]
+    fn cuda_tq2_gemv_parity_k256() {
+        run_case(64, 256, 0xDEAD_0002);
+    }
+
+    /// 1.7B-ish inner dim (hidden=2048 → 16 blocks/row).
+    #[test]
+    fn cuda_tq2_gemv_parity_k2048() {
+        run_case(256, 2048, 0xDEAD_0003);
+    }
+}

--- a/crates/oxibonsai-model/src/model/types/forward_cuda/q1.rs
+++ b/crates/oxibonsai-model/src/model/types/forward_cuda/q1.rs
@@ -317,9 +317,21 @@ impl<'a> BonsaiModel<'a> {
         if n_layers == 0 {
             return Err("no blocks".into());
         }
-        // Ternary batch prefill: route to dedicated TQ2 batch GEMM path (Phase 20A).
+        // Ternary batch prefill is DISABLED on CUDA: it writes the prompt KV into
+        // the prefill-private GPU KV cache (`prefill_state().kv_cache`) while the
+        // per-token decode path reads a *different* cache (`FULL_LAYER_STATE`),
+        // so prompts longer than ~16 tokens make decode attend over stale KV and
+        // produce corrupted output (measured decode logit Δ vs CPU ≈ 7.3 at a
+        // 17-token prompt; ≈ 0.002 via the sequential fallback). This path was
+        // never validated on CUDA hardware. Returning Err makes the caller fall
+        // back to the proven, bit-correct sequential per-token prefill (which
+        // shares the decode KV cache). The Q1 (1-bit) batch path below is fine.
+        // TODO: re-enable once the prefill→decode KV handoff is fixed and a
+        // CPU↔CUDA parity gate (see cuda_ternary_forward_parity.rs) covers it.
         if matches!(&self.output_weight, OutputWeight::Ternary(_)) {
-            return self.try_cuda_prefill_with_lm_head_ternary(token_ids, pos_start);
+            return Err(
+                "ternary CUDA batch prefill disabled (KV-cache handoff bug); using sequential".into(),
+            );
         }
         // Q4_0/Q8_0 batch prefill: route to dedicated Q-std batch GEMM path (Phase 24B).
         if matches!(

--- a/crates/oxibonsai-model/src/model/types/forward_cuda/ternary.rs
+++ b/crates/oxibonsai-model/src/model/types/forward_cuda/ternary.rs
@@ -103,6 +103,11 @@ impl<'a> BonsaiModel<'a> {
     ///
     /// Returns the last token's logits.  Mirrors `try_cuda_prefill_with_lm_head` but
     /// uses TQ2 GEMM/GEMV kernels throughout.
+    ///
+    /// Currently unused: the caller (`try_cuda_prefill_with_lm_head`) disables this
+    /// path because of a prefill→decode KV-cache handoff bug (see the dispatcher in
+    /// `forward_cuda/q1.rs`). Kept so it can be re-enabled once fixed.
+    #[allow(dead_code)]
     pub(super) fn try_cuda_prefill_with_lm_head_ternary(
         &self,
         token_ids: &[u32],

--- a/crates/oxibonsai-runtime/tests/cuda_ternary_forward_parity.rs
+++ b/crates/oxibonsai-runtime/tests/cuda_ternary_forward_parity.rs
@@ -1,0 +1,128 @@
+//! CUDA ternary (TQ2_0_g128) CPU↔GPU parity gate.
+//!
+//! The cross-backend determinism guard (`cross_backend_determinism_tests.rs`)
+//! only covers Metal; the CUDA ternary path was historically "deferred, needs
+//! hw". This test fills that gap on real CUDA hardware: it drives the real
+//! ternary GGUF on the scalar CPU reference (`KernelTier::Reference`) and the
+//! CUDA GPU path (`KernelTier::Gpu`) and asserts identical greedy output.
+//!
+//! It is what surfaced the prefill→decode KV-cache handoff bug: with the CUDA
+//! TQ2 batch prefill enabled, prompts longer than ~16 tokens diverged from CPU
+//! by a large margin (decode logit Δ ≈ 7.3) because batch prefill writes the
+//! prompt KV into a prefill-private cache that the per-token decode path never
+//! reads. With that path disabled (the fix), the sequential per-token prefill
+//! shares the decode KV cache and CPU↔CUDA agree (decode Δ ≈ 0.002).
+//!
+//! Ignored by default (needs the multi-GB model + a CUDA GPU). Run with:
+//!   OXI_MODEL=/abs/path/Ternary-Bonsai-8B.gguf \
+//!     cargo test -p oxibonsai-runtime --features native-cuda \
+//!     --test cuda_ternary_forward_parity -- --ignored --nocapture
+
+#![cfg(all(
+    feature = "native-cuda",
+    any(target_os = "linux", target_os = "windows")
+))]
+
+use oxibonsai_core::gguf::reader::GgufFile;
+use oxibonsai_kernels::dispatch::{KernelDispatcher, KernelTier};
+use oxibonsai_model::model::BonsaiModel;
+use oxibonsai_runtime::engine::InferenceEngine;
+use oxibonsai_runtime::sampling::SamplingParams;
+
+const MAX_SEQ: usize = 512;
+
+fn greedy_params() -> SamplingParams {
+    SamplingParams {
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        repetition_penalty: 1.0,
+        max_tokens: 128,
+    }
+}
+
+/// Greedily generate `n` tokens from `prompt` on the given kernel tier.
+fn run(gguf_bytes: &[u8], tier: KernelTier, prompt: &[u32], n: usize) -> Vec<u32> {
+    let gguf = GgufFile::parse(gguf_bytes).expect("parse gguf");
+    let model = BonsaiModel::from_gguf(&gguf, MAX_SEQ).expect("from_gguf");
+    let mut engine = InferenceEngine::from_model_with_tier(model, tier, greedy_params(), 42);
+    engine.generate(prompt, n).expect("generate")
+}
+
+fn read_model() -> Option<Vec<u8>> {
+    let path = std::env::var("OXI_MODEL")
+        .unwrap_or_else(|_| "models/Ternary-Bonsai-8B.gguf".to_string());
+    match std::fs::read(&path) {
+        Ok(b) => Some(b),
+        Err(e) => {
+            eprintln!("skip: cannot read OXI_MODEL ({path}): {e}");
+            None
+        }
+    }
+}
+
+/// Greedy CPU-reference vs CUDA-Gpu output must match on the real ternary model.
+/// The prompt length is the regression trigger (the bug appeared above ~16
+/// tokens); override the count via `OXI_PROMPT_LEN` (default 20, i.e. >16).
+#[test]
+#[ignore = "requires real ternary GGUF + CUDA GPU; run with --ignored"]
+fn real_ternary_cpu_cuda_parity() {
+    let Some(gguf) = read_model() else { return };
+    let plen: usize = std::env::var("OXI_PROMPT_LEN")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20);
+    let prompt: Vec<u32> = (0..plen as u32).map(|i| 1000 + i * 37).collect();
+    let n = 4;
+    let cpu = run(&gguf, KernelTier::Reference, &prompt, n);
+    let cuda = run(&gguf, KernelTier::Gpu, &prompt, n);
+    eprintln!("── real model (plen={plen}) ──\n  cpu  = {cpu:?}\n  cuda = {cuda:?}");
+    let first = cpu
+        .iter()
+        .zip(cuda.iter())
+        .position(|(a, b)| a != b)
+        .map(|i| i as i32)
+        .unwrap_or(-1);
+    assert_eq!(cpu, cuda, "real ternary CPU vs CUDA diverge (first diff at index {first})");
+}
+
+/// Diagnostic: magnitude of the CPU-vs-CUDA logit divergence at the first decode
+/// step. Benign FP non-associativity is ~1e-2; the KV-handoff bug produced ~7.
+/// Useful to distinguish a near-tie argmax flip from genuine corruption.
+#[test]
+#[ignore = "requires real ternary GGUF + CUDA GPU; run with --ignored"]
+fn real_ternary_decode_logit_delta() {
+    let Some(gguf) = read_model() else { return };
+    let plen: usize = std::env::var("OXI_PROMPT_LEN")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20);
+    let prompt: Vec<u32> = (0..plen as u32).map(|i| 1000 + i * 37).collect();
+
+    let drive = |tier: KernelTier| -> (Vec<f32>, Vec<f32>) {
+        let parsed = GgufFile::parse(&gguf).expect("parse");
+        let mut model = BonsaiModel::from_gguf(&parsed, MAX_SEQ).expect("from_gguf");
+        let kernel = KernelDispatcher::with_tier(tier);
+        let p = model.forward_prefill(&prompt, 0, &kernel).expect("prefill");
+        let tok0 = p
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i as u32)
+            .unwrap();
+        let d = model.forward(tok0, plen, &kernel).expect("decode");
+        (p, d)
+    };
+    let (cpu_p, cpu_d) = drive(KernelTier::Reference);
+    let (cuda_p, cuda_d) = drive(KernelTier::Gpu);
+    let maxd = |a: &[f32], b: &[f32]| a.iter().zip(b).map(|(x, y)| (x - y).abs()).fold(0f32, f32::max);
+    eprintln!("── real logit delta (plen={plen}) ──");
+    eprintln!("  PREFILL max|Δ|={:.4}", maxd(&cpu_p, &cuda_p));
+    eprintln!("  DECODE  max|Δ|={:.4}", maxd(&cpu_d, &cuda_d));
+    // Decode must stay within FP-noise of the CPU reference.
+    assert!(
+        maxd(&cpu_d, &cuda_d) < 0.5,
+        "decode logit divergence too large: {:.4}",
+        maxd(&cpu_d, &cuda_d)
+    );
+}


### PR DESCRIPTION
The CUDA TQ2 batch-prefill path writes the prompt KV into a prefill-private GPU KV cache (prefill_state().kv_cache), while the per-token decode path reads a different cache (FULL_LAYER_STATE.kv_cache). For prompts longer than ~16 tokens the decode step then attends over stale KV and produces corrupted output. Measured on an RTX 5090 (Blackwell, CUDA 13.2): first decode-step logit delta vs the scalar CPU reference was ~7.3 at a 17-token prompt, vs ~0.002 with the batch path disabled.

This path was never validated on CUDA hardware (the cross-backend determinism guard only covers Metal). Route ternary prompts through the existing, proven sequential per-token prefill instead, which shares the decode KV cache and is bit-correct. The Q1 (1-bit) batch path and the decode hot path are unchanged, so generation throughput is unaffected.

Add the missing CUDA CPU<->GPU parity gates that surfaced this:
- cuda_ternary_forward_parity.rs: real-model greedy parity + decode logit-delta
- cuda_tq2_gemv_parity.rs: isolated TQ2 GEMV kernel parity

## Description
<!-- Briefly describe the changes in this PR -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] AI/ML related functionality

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes -->
- [ ] Unit tests
- [ ] Integration tests
- [ ] Performance tests (if relevant)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
<!-- Add any other context about the PR here -->