### PR TITLE
Add gitignore for image-gen assets to keep the clone clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,12 @@ Thumbs.db
 
 # DL models
 models/*
+
+# Image-gen assets (HuggingFace downloads + converted GGUF) and generated output
+# See docs/IMAGEN.md. These land in the repo root and would otherwise dirty the tree.
+bonsai-assets/
+bonsai-dit/
+bonsai-te/
+bonsai-vae/
+flux2/
+*.png


### PR DESCRIPTION
Following `docs/IMAGEN.md` drops a few multi-GB directories into the repo root: the HuggingFace download dirs (`bonsai-assets/`, `bonsai-dit/`, `bonsai-te/`, `bonsai-vae/`, `flux2/`) and the generated PNGs. The `*.gguf`/`*.safetensors` rules already cover the big weights, but the surrounding download dirs, cache metadata, and output images still show up in `git status`.

Add ignores for the asset download dirs and `*.png` so a clone stays clean after a run-through of the image guide. No tracked PNGs today, so `*.png` is safe.
