### PR TITLE
Add `oxibonsai repl` for resident, interactive image generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,12 @@ Thumbs.db
 
 # DL models
 models/*
+
+# Image-gen assets (HuggingFace downloads + converted GGUF) and generated output
+# See docs/IMAGEN.md. These land in the repo root and would otherwise dirty the tree.
+bonsai-assets/
+bonsai-dit/
+bonsai-te/
+bonsai-vae/
+flux2/
+*.png

--- a/crates/oxibonsai-image/src/lib.rs
+++ b/crates/oxibonsai-image/src/lib.rs
@@ -76,6 +76,8 @@ pub mod png;
 /// position-id, and flow-match schedule generators. Makes the text-to-image
 /// pipeline self-sufficient (no golden `.npy` dump for scaffolding).
 pub mod sample;
+/// Resident multi-prompt session: load the pipeline once, render many prompts.
+pub mod session;
 pub mod te;
 pub mod vae;
 pub mod weights;
@@ -87,4 +89,5 @@ pub use pipeline::{
     text_to_image, GoldenOverride, PipelineError, TeSource, TextToImageCfg, TextToImageOut,
 };
 pub use png::{encode_rgb8, PngError, PngResult};
+pub use session::{ImageSession, RenderOutcome, RenderParams, StageTimings};
 pub use weights::{Bf16Tensor, DitWeights, QuantizedLinear};

--- a/crates/oxibonsai-image/src/pipeline.rs
+++ b/crates/oxibonsai-image/src/pipeline.rs
@@ -360,6 +360,40 @@ fn vae_path_present(path: &std::path::Path) -> bool {
     path.is_file() || path.is_dir()
 }
 
+/// Convert a VAE-decoded planar CHW f32 tensor into a row-major HWC u8 RGB
+/// buffer: `px = clip(x / 2 + 0.5, 0, 1) * 255`.
+///
+/// Shared by [`text_to_image`] and [`crate::session::ImageSession`] so both
+/// produce byte-identical pixels. Returns `(width, height, rgb)`.
+///
+/// # Errors
+/// [`PipelineError::Shape`] if `c != 3`.
+pub(crate) fn decoded_chw_to_rgb8(
+    c: usize,
+    h: usize,
+    w: usize,
+    data: &[f32],
+) -> Result<(usize, usize, Vec<u8>), PipelineError> {
+    if c != 3 {
+        return Err(PipelineError::Shape(format!(
+            "expected 3 output channels, got {c}"
+        )));
+    }
+    let plane = h * w;
+    let mut rgb = vec![0u8; data.len()];
+    for y in 0..h {
+        for x in 0..w {
+            let hw = y * w + x;
+            let dst = (y * w + x) * 3;
+            for ch in 0..3 {
+                let v = (data[ch * plane + hw] / 2.0 + 0.5).clamp(0.0, 1.0);
+                rgb[dst + ch] = (v * 255.0).round() as u8;
+            }
+        }
+    }
+    Ok((w, h, rgb))
+}
+
 /// Run the whole text→image pipeline and return the encoded PNG.
 ///
 /// See the [module docs](self) for the stage-by-stage flow.
@@ -548,26 +582,7 @@ pub fn text_to_image(cfg: &TextToImageCfg) -> Result<TextToImageOut, PipelineErr
     }
 
     // ── 6. px = clip(x/2 + 0.5, 0, 1); NCHW → HWC; u8 ──
-    let c = decoded.c;
-    let h = decoded.h;
-    let w = decoded.w;
-    if c != 3 {
-        return Err(PipelineError::Shape(format!(
-            "expected 3 output channels, got {c}"
-        )));
-    }
-    let plane = h * w;
-    let mut rgb = vec![0u8; decoded.data.len()];
-    for y in 0..h {
-        for x in 0..w {
-            let hw = y * w + x;
-            let dst = (y * w + x) * 3;
-            for ch in 0..3 {
-                let v = (decoded.data[ch * plane + hw] / 2.0 + 0.5).clamp(0.0, 1.0);
-                rgb[dst + ch] = (v * 255.0).round() as u8;
-            }
-        }
-    }
+    let (w, h, rgb) = decoded_chw_to_rgb8(decoded.c, decoded.h, decoded.w, &decoded.data)?;
 
     // ── 7. PNG-encode ──
     let t_png = std::time::Instant::now();

--- a/crates/oxibonsai-image/src/session.rs
+++ b/crates/oxibonsai-image/src/session.rs
@@ -1,0 +1,240 @@
+//! Resident image-generation session.
+//!
+//! [`ImageSession`] loads the DiT, VAE, text encoder, and tokenizer **once** and
+//! holds them in memory, so a long-running front-end (e.g. the `oxibonsai repl`
+//! command) can render many prompts without re-paying the per-call load and
+//! 4-bit dequant cost. The text encoder is opened in *resident* mode
+//! ([`TeWeights::set_resident`]): its dequantised f32 weights (~16 GB) stay
+//! cached across renders instead of being thrown away after each forward. That
+//! trades RAM for speed and is intended for high-memory machines.
+//!
+//! The per-render math is identical to the native (non-golden) path of
+//! [`crate::pipeline::text_to_image`] — both share
+//! [`crate::pipeline::decoded_chw_to_rgb8`] and the same `sample`/`forward`
+//! stages, so a session render and a one-shot render of the same
+//! `(prompt, seed, steps, size)` produce byte-identical PNGs.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crate::pipeline::{
+    decoded_chw_to_rgb8, latent_seq_to_packed_nchw, PipelineError, TeSource, TextToImageOut,
+};
+use crate::png::encode_rgb8;
+use crate::sample;
+use crate::te::{Qwen3Tokenizer, TeWeights, TextEncoder};
+use crate::vae::{VaeDecoder, VaeWeights};
+use crate::{DitForward, DitWeights};
+
+/// The fixed text sequence length the DiT conditioning expects (tokenizer pad).
+const SEQ_TXT: usize = 512;
+
+/// Per-render knobs. Mirrors the relevant fields of
+/// [`crate::pipeline::TextToImageCfg`], minus the model paths (those are fixed
+/// for the life of the session) and golden-parity overrides.
+#[derive(Debug, Clone)]
+pub struct RenderParams {
+    /// The text prompt.
+    pub prompt: String,
+    /// RNG seed for the initial noise.
+    pub seed: u64,
+    /// Number of Euler sampler steps.
+    pub steps: usize,
+    /// Target width in pixels.
+    pub width: usize,
+    /// Target height in pixels.
+    pub height: usize,
+    /// Guidance scale (surfaced for parity; the DiT forward is unconditional).
+    pub guidance: f32,
+}
+
+impl Default for RenderParams {
+    fn default() -> Self {
+        Self {
+            prompt: String::new(),
+            seed: 42,
+            steps: 4,
+            width: 512,
+            height: 512,
+            guidance: 1.0,
+        }
+    }
+}
+
+/// Wall-clock split of a single [`ImageSession::render`], so a front-end can
+/// show where the time went (the same stages the `OXI_IMAGE_TIMING` taps print).
+#[derive(Debug, Clone, Copy)]
+pub struct StageTimings {
+    /// Tokenize + text-encoder forward.
+    pub te_encode: Duration,
+    /// DiT flow-matching sampler (all steps).
+    pub dit_sample: Duration,
+    /// VAE decode.
+    pub vae_decode: Duration,
+    /// CHW→RGB + PNG encode.
+    pub png_encode: Duration,
+    /// End-to-end render time.
+    pub total: Duration,
+}
+
+/// The result of one render: the encoded image plus its stage timings.
+pub struct RenderOutcome {
+    /// The encoded PNG and its dimensions.
+    pub image: TextToImageOut,
+    /// Per-stage wall-clock split.
+    pub timings: StageTimings,
+}
+
+/// A loaded, resident text-to-image pipeline. Build once with [`Self::load`],
+/// then call [`Self::render`] per prompt.
+pub struct ImageSession {
+    dit_weights: DitWeights,
+    vae: VaeDecoder,
+    te_weights: TeWeights,
+    tokenizer: Qwen3Tokenizer,
+    in_channels: usize,
+    joint_dim: usize,
+}
+
+impl ImageSession {
+    /// Load every model asset and keep it resident.
+    ///
+    /// `te_source` selects the 4-bit MLX safetensors or the f32 `.npy` dir, same
+    /// as [`crate::pipeline::TextToImageCfg`]. The text encoder is put in
+    /// resident mode so its dequantised weights persist across renders.
+    ///
+    /// # Errors
+    /// [`PipelineError`] wrapping whichever asset failed to load.
+    pub fn load(
+        dit_gguf: &Path,
+        vae_weights: &Path,
+        te_source: &TeSource,
+        tokenizer_dir: &Path,
+    ) -> Result<Self, PipelineError> {
+        let dit_weights = DitWeights::open(dit_gguf)?;
+        let dcfg = dit_weights.config();
+        let in_channels = dcfg.in_channels as usize;
+        let joint_dim = dcfg.joint_attention_dim as usize;
+
+        // VaeDecoder owns its weights, so the loader's buffers can be released.
+        let vae_loaded = VaeWeights::open(vae_weights)?;
+        let vae = VaeDecoder::from_weights(&vae_loaded)?;
+        drop(vae_loaded);
+
+        let te_weights = match te_source {
+            TeSource::Mlx4bit(p) => TeWeights::open_mlx_4bit(p)?,
+            TeSource::NpyDir(d) => TeWeights::open(d)?,
+        };
+        te_weights.set_resident(true);
+
+        let tokenizer = Qwen3Tokenizer::open(tokenizer_dir)?;
+
+        Ok(Self {
+            dit_weights,
+            vae,
+            te_weights,
+            tokenizer,
+            in_channels,
+            joint_dim,
+        })
+    }
+
+    /// Populate the resident text-encoder cache so the *first* real render runs
+    /// at warm speed. A single short encode touches every layer's weights, so
+    /// one pass dequantises the whole encoder. Returns how long warming took.
+    ///
+    /// DiT and VAE weights are memory-mapped and page in lazily; this only warms
+    /// the encoder, which is the dominant amortizable (re-dequant) cost.
+    ///
+    /// # Errors
+    /// [`PipelineError`] if the warm-up encode fails.
+    pub fn warm(&self) -> Result<Duration, PipelineError> {
+        let t = Instant::now();
+        let _ = self.encode("warmup")?;
+        Ok(t.elapsed())
+    }
+
+    /// Tokenize and text-encode `prompt` into the `[SEQ_TXT * joint_dim]`
+    /// conditioning vector.
+    fn encode(&self, prompt: &str) -> Result<Vec<f32>, PipelineError> {
+        let toks = self.tokenizer.tokenize(prompt, SEQ_TXT)?;
+        let encoder = TextEncoder::new(&self.te_weights);
+        let out = encoder.forward(&toks.input_ids, &toks.attention_mask)?;
+        let cond = out.cond_7680()?;
+        let need = SEQ_TXT * self.joint_dim;
+        if cond.len() != need {
+            return Err(PipelineError::Shape(format!(
+                "TE cond len {} != SEQ_TXT*joint_dim ({SEQ_TXT}*{})",
+                cond.len(),
+                self.joint_dim
+            )));
+        }
+        Ok(cond)
+    }
+
+    /// Render one image. Reuses the resident weights; nothing is re-loaded.
+    ///
+    /// # Errors
+    /// [`PipelineError`] wrapping whichever stage failed.
+    pub fn render(&self, params: &RenderParams) -> Result<RenderOutcome, PipelineError> {
+        let t_total = Instant::now();
+
+        let (lat_h, lat_w) = sample::latent_grid(params.height, params.width);
+        let seq_img = lat_h * lat_w;
+
+        // ── 1. Conditioning ──
+        let t_te = Instant::now();
+        let cond_vec = self.encode(&params.prompt)?;
+        let te_encode = t_te.elapsed();
+
+        // ── 2. DiT sampling ──
+        let t_dit = Instant::now();
+        let fwd = DitForward::new(&self.dit_weights);
+        let init = sample::create_noise(params.seed, params.height, params.width);
+        if init.len() != seq_img * self.in_channels {
+            return Err(PipelineError::Shape(format!(
+                "native noise len {} != {seq_img}*{} (in_channels vs PACKED_CHANNELS {})",
+                init.len(),
+                self.in_channels,
+                sample::PACKED_CHANNELS
+            )));
+        }
+        let img_ids = sample::img_ids(lat_h, lat_w);
+        let txt_ids = sample::txt_ids(SEQ_TXT);
+        let (timesteps, sigmas) = sample::flow_match_schedule(seq_img, params.steps);
+        let latent = fwd.sample(
+            &init, &cond_vec, &img_ids, &txt_ids, seq_img, SEQ_TXT, &timesteps, &sigmas, None,
+        )?;
+        let dit_sample = t_dit.elapsed();
+
+        // ── 3. VAE decode ──
+        let t_vae = Instant::now();
+        let packed = latent_seq_to_packed_nchw(&latent, seq_img, self.in_channels, lat_h, lat_w)?;
+        let decoded = self
+            .vae
+            .decode_packed_latents(&packed, lat_h, lat_w, None)?;
+        let vae_decode = t_vae.elapsed();
+
+        // ── 4. Pixels + PNG ──
+        let t_png = Instant::now();
+        let (w, h, rgb) = decoded_chw_to_rgb8(decoded.c, decoded.h, decoded.w, &decoded.data)?;
+        let png = encode_rgb8(w, h, &rgb)?;
+        let png_encode = t_png.elapsed();
+
+        Ok(RenderOutcome {
+            image: TextToImageOut {
+                png,
+                width: w,
+                height: h,
+                stage_cosines: Vec::new(),
+            },
+            timings: StageTimings {
+                te_encode,
+                dit_sample,
+                vae_decode,
+                png_encode,
+                total: t_total.elapsed(),
+            },
+        })
+    }
+}

--- a/crates/oxibonsai-image/src/te/weights.rs
+++ b/crates/oxibonsai-image/src/te/weights.rs
@@ -20,7 +20,7 @@
 //! shared [`crate::gemm::gemm_abt`] (`out[m,n] = Σ_k in[m,k] · w[n,k]`) directly,
 //! computing `x · Wᵀ` — the same contraction the DiT linears use.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -70,6 +70,13 @@ pub struct TeWeights {
     source: Source,
     config: TeConfig,
     cache: RefCell<HashMap<String, Rc<Tensor>>>,
+    /// When set, the [`Source::Mlx4bit`] path also caches its dequantised f32
+    /// tensors (like the `.npy` path always does), trading RAM for speed so a
+    /// long-lived registry pays the dequant cost once instead of once per
+    /// forward. Default off: the one-shot CLI keeps its ~2.5 GB low-RAM
+    /// profile; [`crate::session::ImageSession`] flips it on to keep the
+    /// ~16 GB of f32 encoder weights resident across REPL prompts.
+    resident: Cell<bool>,
 }
 
 impl TeWeights {
@@ -96,6 +103,7 @@ impl TeWeights {
             source: Source::NpyDir(dir.to_path_buf()),
             config,
             cache: RefCell::new(HashMap::new()),
+            resident: Cell::new(false),
         })
     }
 
@@ -116,12 +124,28 @@ impl TeWeights {
             source: Source::Mlx4bit(Box::new(model)),
             config: TeConfig::default(),
             cache: RefCell::new(HashMap::new()),
+            resident: Cell::new(false),
         })
     }
 
     /// The parsed (or default) text-encoder configuration.
     pub fn config(&self) -> &TeConfig {
         &self.config
+    }
+
+    /// Keep dequantised f32 weights resident across forwards.
+    ///
+    /// Off by default. The `.npy` source already caches every tensor; this only
+    /// changes the [`Source::Mlx4bit`] path, which otherwise re-dequantises each
+    /// weight on every [`Self::get`] (the deliberate low-RAM policy). Turning it
+    /// on holds the full f32 encoder (~16 GB) resident so repeated forwards skip
+    /// the dequant. Intended for a long-lived [`crate::session::ImageSession`] on
+    /// a high-memory machine, not the one-shot CLI.
+    pub fn set_resident(&self, on: bool) {
+        self.resident.set(on);
+        if !on {
+            self.cache.borrow_mut().clear();
+        }
     }
 
     /// Fetch a tensor by dotted name.
@@ -170,8 +194,21 @@ impl TeWeights {
                 self.cache.borrow_mut().insert(name.to_string(), t.clone());
                 Ok(t)
             }
-            // No-cache: the dequantised f32 is transient (the core RAM win).
-            Source::Mlx4bit(model) => Ok(Rc::new(model.load_tensor(name)?)),
+            // Default: no-cache, the dequantised f32 is transient (the core RAM
+            // win). When `resident` is set, cache like the `.npy` path so a
+            // long-lived registry dequantises each tensor at most once.
+            Source::Mlx4bit(model) => {
+                if self.resident.get() {
+                    if let Some(t) = self.cache.borrow().get(name) {
+                        return Ok(t.clone());
+                    }
+                    let t = Rc::new(model.load_tensor(name)?);
+                    self.cache.borrow_mut().insert(name.to_string(), t.clone());
+                    Ok(t)
+                } else {
+                    Ok(Rc::new(model.load_tensor(name)?))
+                }
+            }
         }
     }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -120,6 +120,60 @@ oxibonsai image --prompt "a tiny bonsai tree in a ceramic pot" --out bonsai.png
 
 ---
 
+### `repl`
+
+Interactive image generation. Loads the DiT, VAE, and text encoder **once** into
+a resident session, then renders prompts you type without re-loading or
+re-dequantising weights. The text encoder is held resident (its dequantised f32
+weights, ~16 GB, stay cached across prompts), so this is meant for high-memory
+machines — it trades RAM for not re-paying the per-prompt warm-up. On a
+kitty-graphics terminal (Ghostty) each image is shown **inline**; elsewhere it is
+written to a file (and optionally opened in a viewer).
+
+Model paths resolve exactly like [`image`](#image) (flag → env → default).
+
+| Flag | Type | Default | Help |
+|------|------|---------|------|
+| `--seed <N>` | u64 | `42` | Initial RNG seed (change at runtime with `:seed`). |
+| `--steps <N>` | usize | `4` | Initial sampler steps (`:steps` / `:fast` / `:hq`). |
+| `--width <N>` | usize | `512` | Initial width in pixels. |
+| `--height <N>` | usize | `512` | Initial height in pixels. |
+| `--guidance <F>` | f32 | `1.0` | Guidance scale. |
+| `--cpu-te` | flag | off | Run the text-encoder GEMM on the CPU instead of the Metal GPU. |
+| `--dit <PATH>` | string | env `OXI_DIT_GGUF`, else `/tmp/parity.gguf` | DiT GGUF path. |
+| `--vae <PATH>` | string | env `OXI_VAE_WEIGHTS` | VAE weights (file or `.npy` dir). |
+| `--te <PATH>` | string | env `OXI_TE_4BIT`, else env `OXI_TE_WEIGHTS` | Text-encoder weights. |
+| `--tokenizer <PATH>` | string | env `OXI_TE_TOKENIZER_DIR`, else the TE dir | Tokenizer directory. |
+
+Inside the REPL, a bare line is a prompt; `:`-prefixed lines are commands:
+
+| Command | Effect |
+|---------|--------|
+| `:fast` | Preset: 2 steps, 384×384 (snappy preview). |
+| `:hq` | Preset: 8 steps, 512×512 (higher quality). |
+| `:steps N` / `:seed N` / `:guidance G` | Set a single parameter. |
+| `:size WxH` | Set output size (or `:size N` for square). |
+| `:out PATH` | Write to `PATH` (no arg → auto `oxibonsai-repl-NNN.png`). |
+| `:open on\|off` | Open each image in a viewer (non-inline terminals). |
+| `:show` | Print current settings. |
+| `:help` | Command reference. |
+| `:quit` | Exit (also Ctrl-D). |
+
+```bash
+# With OXI_DIT_GGUF / OXI_VAE_WEIGHTS / OXI_TE_4BIT set in the environment:
+oxibonsai repl
+oxibonsai> :fast
+oxibonsai> a red fox in the snow
+oxibonsai> :hq
+oxibonsai> a red fox in the snow
+```
+
+After loading, each render reuses the resident weights, so per-prompt time is
+just compute (text-encode + DiT sampling + VAE decode); the one-time load and
+encoder warm-up are paid once at startup.
+
+---
+
 ### `chat`
 
 Interactive multi-turn conversation. Type `quit` / `exit` or press Ctrl-D to

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -1,0 +1,286 @@
+//! Interactive image REPL (`oxibonsai repl`).
+//!
+//! Loads the text-to-image pipeline once into a resident
+//! [`oxibonsai_image::ImageSession`] and then reads prompts from stdin, rendering
+//! each without re-loading or re-dequantising weights. On a kitty-graphics
+//! terminal (Ghostty) the result is shown inline; elsewhere it is written to a
+//! file. `:`-prefixed lines are commands (see [`print_help`]).
+
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+
+use oxibonsai_image::pipeline::TeSource;
+use oxibonsai_image::{ImageSession, RenderParams};
+
+use super::term;
+
+/// Resolved model asset paths for the session.
+pub struct ReplPaths {
+    /// DiT GGUF path.
+    pub dit: String,
+    /// VAE weights path (file or dir).
+    pub vae: String,
+    /// Text-encoder source.
+    pub te_source: TeSource,
+    /// Tokenizer directory.
+    pub tokenizer_dir: PathBuf,
+}
+
+/// Whether a command loop iteration should keep going or exit.
+enum Control {
+    Continue,
+    Quit,
+}
+
+/// Load the session and run the read-render loop until EOF or `:quit`.
+///
+/// `gpu_te` opts the text encoder onto the Metal GEMM path (`OXI_TE_GPU=1`),
+/// set before the first forward so the one-shot env latch takes effect.
+pub fn run(paths: ReplPaths, mut params: RenderParams, gpu_te: bool) -> anyhow::Result<()> {
+    if gpu_te && std::env::var_os("OXI_TE_GPU").is_none() {
+        // Safe on edition 2021; set before any TE forward so the OnceCell latch
+        // in the GPU dispatch reads it.
+        std::env::set_var("OXI_TE_GPU", "1");
+    }
+
+    println!("Loading models (resident)…");
+    let t = std::time::Instant::now();
+    let session = ImageSession::load(
+        Path::new(&paths.dit),
+        Path::new(&paths.vae),
+        &paths.te_source,
+        &paths.tokenizer_dir,
+    )?;
+    println!("  loaded in {:.1}s", t.elapsed().as_secs_f64());
+
+    print!("Warming text encoder…");
+    io::stdout().flush().ok();
+    match session.warm() {
+        Ok(d) => println!(" {:.1}s", d.as_secs_f64()),
+        Err(e) => println!(" skipped ({e})"),
+    }
+
+    let inline = term::kitty_supported();
+    let mut open_fallback = !inline;
+    let mut out_template: Option<String> = None;
+    let mut counter = 0usize;
+
+    banner(inline, gpu_te);
+
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+    loop {
+        print!("\noxibonsai> ");
+        io::stdout().flush().ok();
+
+        let Some(line) = lines.next() else {
+            break; // EOF (Ctrl-D)
+        };
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(cmd) = trimmed.strip_prefix(':') {
+            match handle_command(cmd, &mut params, &mut out_template, &mut open_fallback) {
+                Control::Continue => continue,
+                Control::Quit => break,
+            }
+        }
+
+        // Anything else is a prompt.
+        params.prompt = trimmed.to_string();
+        match session.render(&params) {
+            Ok(outcome) => {
+                counter += 1;
+                let path = out_template
+                    .clone()
+                    .unwrap_or_else(|| format!("oxibonsai-repl-{counter:03}.png"));
+                if let Err(e) = std::fs::write(&path, &outcome.image.png) {
+                    eprintln!("  write {path}: {e}");
+                }
+
+                if inline {
+                    let mut so = io::stdout().lock();
+                    if term::display_png_kitty(&mut so, &outcome.image.png).is_err() {
+                        println!("  (inline display failed; wrote {path})");
+                    }
+                } else {
+                    println!("  wrote {path}");
+                    if open_fallback {
+                        let _ = std::process::Command::new("open").arg(&path).status();
+                    }
+                }
+
+                let ti = outcome.timings;
+                println!(
+                    "  {}x{}  {:.1}s total  (TE {:.1}s · DiT {:.1}s · VAE {:.1}s)  seed={} steps={}",
+                    outcome.image.width,
+                    outcome.image.height,
+                    ti.total.as_secs_f64(),
+                    ti.te_encode.as_secs_f64(),
+                    ti.dit_sample.as_secs_f64(),
+                    ti.vae_decode.as_secs_f64(),
+                    params.seed,
+                    params.steps,
+                );
+            }
+            Err(e) => eprintln!("  render failed: {e}"),
+        }
+    }
+
+    println!("bye");
+    Ok(())
+}
+
+/// Dispatch a `:`-command. Returns whether to continue or quit.
+fn handle_command(
+    cmd: &str,
+    params: &mut RenderParams,
+    out_template: &mut Option<String>,
+    open_fallback: &mut bool,
+) -> Control {
+    let mut it = cmd.split_whitespace();
+    let Some(name) = it.next() else {
+        return Control::Continue;
+    };
+    let arg = it.next();
+
+    match name {
+        "q" | "quit" | "exit" => return Control::Quit,
+        "h" | "help" | "?" => print_help(),
+        "show" | "set" => print_settings(params, out_template, *open_fallback),
+        "steps" => match arg.and_then(|a| a.parse().ok()) {
+            Some(v) => {
+                params.steps = v;
+                println!("  steps = {v}");
+            }
+            None => eprintln!("  usage: :steps N"),
+        },
+        "seed" => match arg.and_then(|a| a.parse().ok()) {
+            Some(v) => {
+                params.seed = v;
+                println!("  seed = {v}");
+            }
+            None => eprintln!("  usage: :seed N"),
+        },
+        "guidance" => match arg.and_then(|a| a.parse().ok()) {
+            Some(v) => {
+                params.guidance = v;
+                println!("  guidance = {v}");
+            }
+            None => eprintln!("  usage: :guidance G"),
+        },
+        "size" => set_size(arg, params),
+        "fast" => {
+            params.steps = 2;
+            params.width = 384;
+            params.height = 384;
+            println!("  preset: fast (2 steps, 384x384)");
+        }
+        "hq" => {
+            params.steps = 8;
+            params.width = 512;
+            params.height = 512;
+            println!("  preset: hq (8 steps, 512x512)");
+        }
+        "out" => {
+            *out_template = arg.map(String::from);
+            match out_template.as_deref() {
+                Some(p) => println!("  output → {p}"),
+                None => println!("  output → auto (oxibonsai-repl-NNN.png)"),
+            }
+        }
+        "open" => match arg {
+            Some("on") => {
+                *open_fallback = true;
+                println!("  open in viewer: on");
+            }
+            Some("off") => {
+                *open_fallback = false;
+                println!("  open in viewer: off");
+            }
+            _ => eprintln!("  usage: :open on|off"),
+        },
+        other => eprintln!("  unknown command :{other}  (try :help)"),
+    }
+    Control::Continue
+}
+
+/// Parse `:size WxH` or `:size N` (square).
+fn set_size(arg: Option<&str>, params: &mut RenderParams) {
+    let Some(a) = arg else {
+        eprintln!("  usage: :size WxH  or  :size N");
+        return;
+    };
+    let parts: Vec<&str> = a.split(['x', 'X', '*']).collect();
+    let (w, h) = match parts.as_slice() {
+        [w, h] => match (w.parse::<usize>(), h.parse::<usize>()) {
+            (Ok(w), Ok(h)) => (w, h),
+            _ => {
+                eprintln!("  bad size (try :size 512x512)");
+                return;
+            }
+        },
+        [n] => match n.parse::<usize>() {
+            Ok(n) => (n, n),
+            Err(_) => {
+                eprintln!("  bad size (try :size 512)");
+                return;
+            }
+        },
+        _ => {
+            eprintln!("  bad size (try :size 512x512)");
+            return;
+        }
+    };
+    params.width = w;
+    params.height = h;
+    println!("  size = {w}x{h}");
+}
+
+/// Opening banner once the session is ready.
+fn banner(inline: bool, gpu_te: bool) {
+    println!();
+    println!("OxiBonsai image REPL — type a prompt and press enter.");
+    println!(
+        "  display: {}   text-encoder: {}",
+        if inline { "inline (kitty)" } else { "file" },
+        if gpu_te { "GPU" } else { "CPU" },
+    );
+    println!("  :help for commands, :quit (or Ctrl-D) to exit.");
+}
+
+/// Print the command reference.
+fn print_help() {
+    println!(
+        "\
+  <text>          render <text> as an image
+  :fast           preset: 2 steps, 384x384 (snappy preview)
+  :hq             preset: 8 steps, 512x512 (higher quality)
+  :steps N        set sampler steps
+  :seed N         set RNG seed
+  :size WxH       set output size (or :size N for square)
+  :guidance G     set guidance scale
+  :out PATH       write to PATH (no arg → auto oxibonsai-repl-NNN.png)
+  :open on|off    open each image in a viewer (non-inline terminals)
+  :show           print current settings
+  :help           this help
+  :quit           exit (also Ctrl-D)"
+    );
+}
+
+/// Print the current render settings.
+fn print_settings(params: &RenderParams, out_template: &Option<String>, open_fallback: bool) {
+    println!(
+        "  steps={}  seed={}  size={}x{}  guidance={}  out={}  open={}",
+        params.steps,
+        params.seed,
+        params.width,
+        params.height,
+        params.guidance,
+        out_template.as_deref().unwrap_or("auto"),
+        if open_fallback { "on" } else { "off" },
+    );
+}

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -1,0 +1,95 @@
+//! Inline terminal image display via the kitty graphics protocol.
+//!
+//! Used by the `oxibonsai repl` command to show a freshly rendered PNG in the
+//! terminal instead of round-tripping through an external viewer. Detection is
+//! deliberately narrow: we only claim support for Ghostty for now (the one
+//! terminal this has been verified against). Other kitty-capable terminals
+//! (kitty, WezTerm) fall through to `false` and the REPL writes a file path
+//! instead — adding them is a one-line change to [`kitty_supported`] once tested.
+
+use std::io::{self, Write};
+
+/// Whether the current terminal speaks the kitty graphics protocol.
+///
+/// Ghostty advertises itself through `GHOSTTY_*` env vars and `TERM`/
+/// `TERM_PROGRAM`; any one of them is enough.
+pub fn kitty_supported() -> bool {
+    if std::env::var_os("GHOSTTY_RESOURCES_DIR").is_some()
+        || std::env::var_os("GHOSTTY_BIN_DIR").is_some()
+    {
+        return true;
+    }
+    if matches!(std::env::var("TERM").as_deref(), Ok("xterm-ghostty")) {
+        return true;
+    }
+    matches!(
+        std::env::var("TERM_PROGRAM").as_deref(),
+        Ok("ghostty") | Ok("Ghostty")
+    )
+}
+
+/// Display a PNG inline using the kitty graphics protocol.
+///
+/// Emits `f=100` (PNG), `a=T` (transmit + display immediately), with the
+/// base64 payload split into 4 KiB chunks (`m=1` on every chunk but the last).
+/// Only the first chunk carries the format/action keys, per the protocol. A
+/// trailing newline advances the cursor below the image.
+pub fn display_png_kitty(out: &mut impl Write, png: &[u8]) -> io::Result<()> {
+    let b64 = base64_encode(png);
+    let mut chunks = b64.as_bytes().chunks(4096).peekable();
+    let mut first = true;
+    while let Some(chunk) = chunks.next() {
+        let more = u8::from(chunks.peek().is_some());
+        if first {
+            write!(out, "\x1b_Gf=100,a=T,m={more};")?;
+            first = false;
+        } else {
+            write!(out, "\x1b_Gm={more};")?;
+        }
+        out.write_all(chunk)?;
+        write!(out, "\x1b\\")?;
+    }
+    writeln!(out)?;
+    out.flush()
+}
+
+/// Standard base64 (RFC 4648, `+/` alphabet, `=` padding).
+fn base64_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut s = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = chunk.get(1).copied().unwrap_or(0);
+        let b2 = chunk.get(2).copied().unwrap_or(0);
+        let n = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+        s.push(ALPHABET[((n >> 18) & 63) as usize] as char);
+        s.push(ALPHABET[((n >> 12) & 63) as usize] as char);
+        s.push(if chunk.len() > 1 {
+            ALPHABET[((n >> 6) & 63) as usize] as char
+        } else {
+            '='
+        });
+        s.push(if chunk.len() > 2 {
+            ALPHABET[(n & 63) as usize] as char
+        } else {
+            '='
+        });
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::base64_encode;
+
+    #[test]
+    fn base64_matches_rfc4648_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,9 @@ mod cli {
 
     use oxibonsai_runtime::OxiBonsaiConfig;
 
+    mod repl;
+    mod term;
+
     #[derive(Parser)]
     #[command(
         name = "oxibonsai",
@@ -114,6 +117,56 @@ mod cli {
 
             /// Text-encoder weights: a 4-bit model.safetensors file or an f32 .npy dir
             /// (default: env OXI_TE_4BIT, else env OXI_TE_WEIGHTS, else /tmp/bonsai_golden/te/weights).
+            #[arg(long)]
+            te: Option<String>,
+
+            /// Tokenizer dir containing tokenizer.json
+            /// (default: env OXI_TE_TOKENIZER_DIR, else the TE dir).
+            #[arg(long)]
+            tokenizer: Option<String>,
+        },
+
+        /// Interactive image REPL: load the pipeline once, render many prompts.
+        ///
+        /// Keeps the DiT, VAE, and (resident) text encoder in memory so each
+        /// prompt skips the load/dequant cost. On Ghostty the image is shown
+        /// inline; elsewhere it is written to a file. Model paths resolve the
+        /// same way as `image` (flag → env → default).
+        Repl {
+            /// Initial RNG seed (changeable at runtime with :seed).
+            #[arg(long, default_value_t = 42)]
+            seed: u64,
+
+            /// Initial sampler steps (changeable with :steps / :fast / :hq).
+            #[arg(long, default_value_t = 4)]
+            steps: usize,
+
+            /// Initial image width in pixels.
+            #[arg(long, default_value_t = 512)]
+            width: usize,
+
+            /// Initial image height in pixels.
+            #[arg(long, default_value_t = 512)]
+            height: usize,
+
+            /// Guidance scale.
+            #[arg(long, default_value_t = 1.0)]
+            guidance: f32,
+
+            /// Run the text-encoder GEMM on the CPU instead of the Metal GPU.
+            #[arg(long)]
+            cpu_te: bool,
+
+            /// DiT GGUF path (default: env OXI_DIT_GGUF or /tmp/parity.gguf).
+            #[arg(long)]
+            dit: Option<String>,
+
+            /// VAE weights path (default: env OXI_VAE_WEIGHTS).
+            #[arg(long)]
+            vae: Option<String>,
+
+            /// Text-encoder weights: a 4-bit model.safetensors file or an f32
+            /// .npy dir (default: env OXI_TE_4BIT, else OXI_TE_WEIGHTS).
             #[arg(long)]
             te: Option<String>,
 
@@ -802,6 +855,77 @@ mod cli {
                     "  seed={seed} steps={steps} guidance={guidance} in {:.1}s",
                     elapsed.as_secs_f64()
                 );
+            }
+
+            Commands::Repl {
+                seed,
+                steps,
+                width,
+                height,
+                guidance,
+                cpu_te,
+                dit,
+                vae,
+                te,
+                tokenizer,
+            } => {
+                use oxibonsai_image::pipeline::TeSource;
+                use oxibonsai_image::RenderParams;
+
+                // Same resolution as `image`: explicit arg → env → default.
+                let resolve = |arg: Option<String>, env: &str, default: &str| -> String {
+                    arg.or_else(|| std::env::var(env).ok().filter(|s| !s.is_empty()))
+                        .unwrap_or_else(|| default.to_string())
+                };
+
+                let dit_path = resolve(dit, "OXI_DIT_GGUF", "/tmp/parity.gguf");
+                let vae_path = resolve(vae, "OXI_VAE_WEIGHTS", "/tmp/bonsai_golden/vae/weights");
+
+                let te_path = te
+                    .or_else(|| std::env::var("OXI_TE_4BIT").ok().filter(|s| !s.is_empty()))
+                    .or_else(|| {
+                        std::env::var("OXI_TE_WEIGHTS")
+                            .ok()
+                            .filter(|s| !s.is_empty())
+                    })
+                    .unwrap_or_else(|| "/tmp/bonsai_golden/te/weights".to_string());
+                let te_source = if te_path.ends_with(".safetensors") {
+                    TeSource::Mlx4bit(PathBuf::from(&te_path))
+                } else {
+                    TeSource::NpyDir(PathBuf::from(&te_path))
+                };
+
+                let tokenizer_dir = tokenizer
+                    .or_else(|| {
+                        std::env::var("OXI_TE_TOKENIZER_DIR")
+                            .ok()
+                            .filter(|s| !s.is_empty())
+                    })
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| {
+                        let p = PathBuf::from(&te_path);
+                        if te_path.ends_with(".safetensors") {
+                            p.parent().map(Path::to_path_buf).unwrap_or(p)
+                        } else {
+                            p
+                        }
+                    });
+
+                let params = RenderParams {
+                    prompt: String::new(),
+                    seed,
+                    steps,
+                    width,
+                    height,
+                    guidance,
+                };
+                let paths = repl::ReplPaths {
+                    dit: dit_path,
+                    vae: vae_path,
+                    te_source,
+                    tokenizer_dir,
+                };
+                repl::run(paths, params, !cpu_te)?;
             }
 
             Commands::Chat {


### PR DESCRIPTION
Adds `oxibonsai repl`: an interactive image-generation mode that loads the pipeline once and renders many prompts without re-paying the per-call load and 4-bit dequant cost. On Ghostty the image renders inline (kitty graphics protocol); other terminals get a file path.

Stacked on #11 (the gitignore change). Until that merges, the diff here includes its one-line commit; GitHub will narrow it once #11 lands.

## Why

The one-shot `image` command reloads and re-dequantises every weight per invocation. The 4-bit text encoder deliberately discards its dequantised f32 weights after each forward to hold RAM at ~2.5 GB, so iterating on prompts re-pays that cost every time. On a high-memory machine the better trade is to spend the RAM and keep everything hot.

## What

- **`ImageSession`** (`oxibonsai-image`): loads DiT + VAE + text encoder + tokenizer once, renders many prompts, returns per-stage timings. Its native path shares the sampler/decode stages and a new `decoded_chw_to_rgb8` helper with `text_to_image`, so a session render is byte-identical to a one-shot render of the same `(prompt, seed, steps, size)`.
- **`TeWeights::set_resident`**: opts the 4-bit MLX source into caching its dequantised f32 weights. Default off, so the one-shot CLI keeps its low-RAM profile; the session turns it on.
- **`oxibonsai repl`**: loads the session, warms the encoder, then reads prompts from stdin. `:fast` / `:hq` presets and `:steps`/`:seed`/`:size`/`:out`/`:open` commands tune renders without restarting. The text-encoder GEMM runs on Metal by default (`--cpu-te` to opt out).
- **Inline display**: Ghostty detection + a dependency-free base64 and chunked kitty-escape encoder in a small `cli::term` module. Narrow on purpose (only Ghostty is claimed today); other kitty terminals fall back to a file path until tested.

Model paths resolve the same way as `image` (flag → env → default). Documented in `docs/CLI.md`.

## Measured (Apple Silicon, Metal, 128 GB)

| Path | Time | Notes |
|------|------|-------|
| Session load | 0.3s | mmap, once |
| Encoder warm | 13.5s | one-time dequant + GPU init |
| `:fast` render (2 steps, 384²) | ~19s | TE ~9s · DiT ~7s · VAE ~4s |
| `:hq` render (8 steps, 512²) | ~63s | DiT ~44s dominates |

The text encoder stays roughly constant regardless of image size (it encodes the fixed-length prompt), so it weighs most on small previews. On Metal the encoder weights are already upload-once and stay resident on the GPU across prompts; the resident f32 cache here is what makes that path correct with 4-bit weights (stable pointers), not just faster. The per-GEMM upload/evict only exists on the CUDA path. The realized TE win in this PR is the masked-key attention skip below.

## Test plan

- [x] `cargo build --release --features metal`
- [x] `cargo clippy --release --features metal -p oxibonsai-image -p oxibonsai-cli -- -D warnings`
- [x] `cargo test --bin oxibonsai` (base64 RFC 4648 vectors)
- [x] Drove the REPL over piped stdin: `:fast`/`:hq`, multiple prompts, inline display detected and emitted under Ghostty, valid PNGs out

## Follow-up: masked-key skip in TE attention (commit ac6fc47)

The text encoder pads every prompt to 512 tokens and masks the rest, but the GQA attention computed all 512×512 query·key dots per head/layer and discarded the masked ones (their `exp(-inf)` softmax weight is 0). Skipping those dots is byte-identical: a `silly bees`/seed 42/4-step render is SHA-256-identical before and after. It drops per-encode attention from **~1.2s to ~0.14s** on a short prompt.

This is on the CPU attention path, so it helps the one-shot `image` command too, not just the REPL.
