### PR TITLE
Skip masked keys in the text-encoder attention

### DIFF
--- a/crates/oxibonsai-image/src/te/forward.rs
+++ b/crates/oxibonsai-image/src/te/forward.rs
@@ -397,6 +397,18 @@ impl<'w> TextEncoder<'w> {
                 let q_row = &q[q_off + qi * head_dim..q_off + (qi + 1) * head_dim];
                 let mrow = &mask[qi * seq..(qi + 1) * seq];
                 for (ki, score) in scores.iter_mut().enumerate() {
+                    // A masked key (causal future or padding) carries an additive
+                    // `-inf`, so its softmax weight is `exp(-inf) = 0` no matter
+                    // the score. Skip the dot entirely and stamp `-inf` directly —
+                    // byte-identical to computing it. For the fixed 512-token
+                    // padded sequence this is the bulk of the work on a short
+                    // prompt (only the real, non-future keys survive). `mask` only
+                    // ever holds `0.0` or `-inf`, so `is_infinite()` is exactly the
+                    // masked set.
+                    if mrow[ki].is_infinite() {
+                        *score = f32::NEG_INFINITY;
+                        continue;
+                    }
                     let k_row = &k[kv_off + ki * head_dim..kv_off + (ki + 1) * head_dim];
                     *score = dot(q_row, k_row, head_dim) * scale + mrow[ki];
                 }


### PR DESCRIPTION
Skips the masked key/query dot products in the text-encoder attention. Byte-identical output, measurable speedup on short prompts.

Follow-up to #12: this commit was pushed to that PR's branch just after it merged, so it didn't make it in. Re-homed here against `0.2.2`.

## Why

The TE tokenizer pads every prompt to a fixed 512-token sequence and masks the rest. The GQA attention still computed all 512×512 query·key dot products per head per layer, then discarded ~all of them: a masked key (causal future or padding) carries an additive `-inf`, so its softmax weight is `exp(-inf) = 0` regardless of the score.

## What

Skip the dot for masked keys and stamp `-inf` directly. The mask only ever holds `0.0` or `-inf`, so this is byte-identical to computing the score.

## Verification

A `silly bees` / seed 42 / 4-step render is SHA-256-identical before and after (CPU TE path, where the change lives). Per-encode attention drops from **~1.2s to ~0.14s** on a short prompt; the gain is larger the shorter the prompt, and the causal mask still trims roughly half the work at full length.

## Test plan

- [x] `cargo build --release --features metal`
- [x] `cargo clippy --release --features metal -p oxibonsai-image -- -D warnings`
- [x] SHA-256 parity A/B (pre-edit vs post-edit binary, same prompt/seed/steps)
